### PR TITLE
Makes Hugo Deployable!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ Rplots.pdf
 
 ## Hugo
 /public
+/docs
 /resources/_gen
 .hugo_build.lock

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Rplots.pdf
 ## Hugo
 /public
 /resources/_gen
+.hugo_build.lock

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,3 @@
-baseURL = "https://preview.infosecforactivists.org/"
 title = "Infosec 101 for Activists"
 theme = "book"
 relativeURLs = true

--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,10 @@
-baseURL = "https://infosecforactivists.org/"
+baseURL = "https://preview.infosecforactivists.org/"
 title = "Infosec 101 for Activists"
 theme = "book"
+relativeURLs = true
 
 # provides 'Last Modified' date
-enableGitInfo = true 
+enableGitInfo = true
 
 [markup]
   [markup.tableOfContents]

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://preview.infosecforactivists.org/"
 title = "Infosec 101 for Activists"
 theme = "book"
 relativeURLs = true
+publishDir = "docs"
 
 # provides 'Last Modified' date
 enableGitInfo = true


### PR DESCRIPTION
Completes the transition to Hugo.

## Significant Changes
* The Hugo configuration no longer contains a value for the `baseURL` parameter. This parameter is required, but can be passed at build time using `--baseURL`.
* The default `publishDir` was changed to `docs` in order to ease publishing to `gh-pages`