### PR TITLE
Jitsi now needs an account

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ name: Deploy Hugo site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["preview"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -328,10 +328,21 @@ Virtual meetings over video calls are part of modern life and very common in act
 communities. Solutions like Zoom, Google Meet, and Microsoft Teams are popular choices for work
 and social meetups but do not offer the privacy activism requires. For that reason, we
 recommend [Jitsi](https://jitsi.org/). Unlike other platforms, Jitsi does not record or retain
-the content of your meetings. Jitsi is free and does not even require a user account. You can
-start a meeting directly from their web page at [meet.jit.si](https://meet.jit.si/). No
-participants need to have accounts or give any personal information to use the
-platform. Jitsi takes security and personal anonymity seriously.
+the content of your meetings. Any data given during the meeting, including name given when 
+joining and chat, will be deleted at the conclusion of the meeting. 
+Jitsi is free and most participants do not need an account. 
+
+We say "most" because Jitsi now requires an account to *create* a meeting space, but joining that 
+space can still be done without an account and without providing any personal information. 
+The person who creates the meeting room must have a Jitsi account, or sign in using an account from 
+Google, GitHub or Facebook. Starting with the second person to join a meeting, no account and no 
+personal information is required. If you need to create a meeting space and require privacy, we 
+recommend you create a [GitHub account](https://github.com/signup) using a throwaway email address,
+and sign into Jitsi using that account. GitHub is a platform for software developers owned by Microsoft. 
+It does not deeply verify accounts. You can read their [privacy statement here](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement).
+
+You can start a meeting directly from their web page at 
+[meet.jit.si](https://meet.jit.si/).  Jitsi takes security and personal anonymity seriously.
 You can read more on their [security page](https://jitsi.org/security/).
 
 ## Password Safety


### PR DESCRIPTION
wording approved with tabled new item: talk about that you can choose the meeting name, the meeting is important, but Jitsi lets you change it. 