### PR TITLE
Fix tabbed table view in 'Phone Setup Instructions'

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -243,7 +243,8 @@ are explained above. The buttons to press, however, are quite different between 
 iPhone or Android below to see the instructions. 
 
 {{< tabs >}}
-{{< tab "iPhone" >}}
+{{% tab "iPhone" %}}
+
 ### iPhone Setup
 
 Apple has prioritized personal security in recent years and now offers features to make securing
@@ -277,9 +278,10 @@ device instead of *Face ID* where it is referenced below.
 		* If you need to quickly lock down the device, press and hold the power button and either of 
 			the volume buttons until the Emergency SOS lock screen appears. At this point, biometric
 			login will be disabled until the passcode is reentered.
-{{< /tab >}}
+			
+{{% /tab %}}
+{{% tab "Android" %}}
 
-{{< tab "Android" >}}
 ### Android Setup
 
 Android has flexible settings that can be used to make your phone secure and usable in a number of situations. 
@@ -311,8 +313,10 @@ Click below to see steps to make your phone generally secure for the day of an a
 	  it, which is dangerous at an action.
 * Go to *Settings → Display → Advanced → Screen timeout* and set it to the shortest possible
   time, usually 15 seconds.
-{{< /tab >}}
+  
+{{% /tab %}}
 {{< /tabs >}}
+
 # Security Ideas
 This section is about keeping your information private in the rest of your life. In this
 document, “private” means only accessible to you, and not to anyone else without your permission.

--- a/content/es/_index.md
+++ b/content/es/_index.md
@@ -115,7 +115,7 @@ _[Android utiliza Google Drive](https://support.google.com/drive/answer/6305834?
 A continuación, tenemos pasos específicos para preparar su iPhone o Android. 
 
 {{< tabs >}}
-{{< tab "iPhone" >}}
+{{% tab "iPhone" %}}
 ### Configuración de iPhone 
 
 Apple le ha dado prioridad a la seguridad en los últimos añosanos y han proveído características
@@ -139,9 +139,9 @@ pueden ser usados para asegurar razonablemente su móvil para una marcha.
     * Presiona and mantenga pulsado el botón de encendido y el botón de volumen hasta que el Emergencia SOS de Emergencia aparezca en la pantalla de bloqueo. Face ID y Touch ID serán desactivados hasta que el código sea ingresado.
 * Desactivar Touch ID y Face ID
     * Configuración → Touch ID y Código, debajo de la sección “Usa Touch ID para:”, arrastra todos los controles deslizantes a la derecha para apagarlos.
-{{< /tab >}}
+{{% /tab %}}
 
-{{< tab "Android" >}}
+{{% tab "Android" %}}
 ### Configuración de Android
 Android tiene configuraciones flexibles que pueden ser usadas para asegurar tu teléfono y hacerlo usable en varias situaciones. A continuación, presentamos pasos para asegurar tu móvil para una marcha. 
 
@@ -162,7 +162,7 @@ Android tiene configuraciones flexibles que pueden ser usadas para asegurar tu t
     * Marque la opción “Bloquear con tecla encendido” 
   * Desactivar Smart Lock si lo tiene. Puede mantener su móvil desbloqueado cuando menos se lo espera, lo cual es peligroso durante una marcha. 
 * Vaya a *configuración → Pantalla y brillo → Avanzado → Bloqueo Automático* y escoja la opción más corta posible, normalmente 15 segundos. 
-{{< /tab >}}
+{{% /tab %}}
 {{< /tabs >}}
 
 # Ideas de Seguridad 


### PR DESCRIPTION
The table didn't render properly before. The tabs were there, but the content was raw markdown without rendering.

---

False lead: https://github.com/rvanhorn/hugo-dynamic-tabs although same keywords, hugo-book (theme used here) provides its own **tabs** shortcodes: https://github.com/alex-shpak/hugo-book?tab=readme-ov-file#shortcodes

Despite the documentation suggesting the use of "unsafe", I found through experimentation, this is not needed. The difference between `{{< shortcode >}}` and `{{% shortcode %}}` is that the former expects HTML (actually our case: the "parent" of tabs injects HTML) and the latter expects Markdown (also us, inner tab content IS Markdown).

I will raise this as a doc issue in hugo-book too.