### PR TITLE
fix: improve printing layout

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,0 +1,13 @@
+@media print {
+    .book-icon {
+        display: none;
+    }
+
+    #TableOfContents {
+        display: none;
+    }
+
+    .book-tabs-content {
+        display: block !important;
+    }
+}


### PR DESCRIPTION
* Hides the table of contents when printing.
* Don't show unnecessary icons when printing.
* Ensure both the iPhone and Android setup sections are visible.

Known issues:
* The android and iPhone setup sections are still treated as a single block when printing. This leads to some weird formatting, and part of the instructions gets split between pages.
* Page breaking needs improvement. Things get oddly split in general.