### PR TITLE
fix: Pins hugo-book version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,32 +6,31 @@ publishDir = "public"
 enableGitInfo = true
 
 [markup.tableOfContents]
-  startLevel = 1
-  endLevel = 2
+startLevel = 1
+endLevel = 2
 
 defaultContentLanguage = 'en'
 [languages]
-  [languages.en]
-    contentDir = 'content/en'
-    languageName = 'English'
-    languageNameShort = 'En'
-    title = 'Infosec for Activists'
-    weight = 1
+[languages.en]
+contentDir = 'content/en'
+languageName = 'English'
+languageNameShort = 'En'
+title = 'Infosec for Activists'
+weight = 1
 
-  [languages.es]
-    contentDir = 'content/es'
-    languageName = 'Español'
-    languageNameShort = 'Es'
-    title = 'Infosec para Activistas'
-    weight = 2
+[languages.es]
+contentDir = 'content/es'
+languageName = 'Español'
+languageNameShort = 'Es'
+title = 'Infosec para Activistas'
+weight = 2
 
 [module]
 [[module.imports]]
-  path = "github.com/alex-shpak/hugo-book"
-  disable = false
+path = "github.com/alex-shpak/hugo-book"
 
 [params]
-  BookTheme = 'auto'
-  BookComments = false
-  BookSection = "*"
-  BookSearch = false
+BookTheme = 'auto'
+BookComments = false
+BookSection = "*"
+BookSearch = false

--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ weight = 2
 
 [module]
 [[module.imports]]
-path = "github.com/alex-shpak/hugo-book"
+path = "github.com/bskinner/hugo-book/v11"
 
 [params]
 BookTheme = 'auto'

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/InfosecForActivistsTeam/infosec-activists
 
 go 1.17
 
-require github.com/alex-shpak/hugo-book v0.0.0-20250720104709-92579b2c7217 // indirect
+require github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/InfosecForActivistsTeam/infosec-activists
 
 go 1.17
 
-require github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb // indirect
+require github.com/bskinner/hugo-book/v11 v11.0.2

--- a/go.sum
+++ b/go.sum
@@ -16,3 +16,7 @@ github.com/alex-shpak/hugo-book v0.0.0-20250428224046-9405c4c3d7c7 h1:jD6Fris8nD
 github.com/alex-shpak/hugo-book v0.0.0-20250428224046-9405c4c3d7c7/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
 github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb h1:0sfgKRz0Wfrv5eS2JO/TN8eWWOsHM6nHwRb8ynPy+x8=
 github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/alex-shpak/hugo-book v0.0.0-20250815075559-80da168330a7 h1:zxGxqYjCcRUPz7r87qtOE/famdnIhqQOD75R9Vt2mpQ=
+github.com/alex-shpak/hugo-book v0.0.0-20250815075559-80da168330a7/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/bskinner/hugo-book/v11 v11.0.2 h1:RqQGrtbAE351FEaiULFNs9bqjUCVhgNd4U01F0aUM6Q=
+github.com/bskinner/hugo-book/v11 v11.0.2/go.mod h1:M26yF0Xs+DD7Ucby6cnH8RpBYJw0K/3EzBbjMo8aklg=

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,5 @@ github.com/alex-shpak/hugo-book v0.0.0-20241009212754-7c78a39c531a h1:GiRJQYc9Bt
 github.com/alex-shpak/hugo-book v0.0.0-20241009212754-7c78a39c531a/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
 github.com/alex-shpak/hugo-book v0.0.0-20250428224046-9405c4c3d7c7 h1:jD6Fris8nDfS/RQcC3J0IfMxeU9YALMU24T+3YSVfXg=
 github.com/alex-shpak/hugo-book v0.0.0-20250428224046-9405c4c3d7c7/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
-github.com/alex-shpak/hugo-book v0.0.0-20250720104709-92579b2c7217 h1:JuqlCjJLjmLAWMBZVbydMROfL2HMwRf+LtwVF8Q7KvQ=
-github.com/alex-shpak/hugo-book v0.0.0-20250720104709-92579b2c7217/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=
+github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb h1:0sfgKRz0Wfrv5eS2JO/TN8eWWOsHM6nHwRb8ynPy+x8=
+github.com/alex-shpak/hugo-book v0.0.0-20250530191531-2acd86a6c2fb/go.mod h1:L4NMyzbn15fpLIpmmtDg9ZFFyTZzw87/lk7M2bMQ7ds=


### PR DESCRIPTION
There was some breakage encountered in a hugo-book update last week. The repo has been forked, changes have been made to get the module in-line with go's versioning scheme, and our version has been pinned to the v11.0.0 release.

# Changes
* Switched hugo-book theme source from `alex-shpak/hugo-book` to `bskinner/hugo-book`
* Pins the version of hugo-book to v11.0.2 (logically identical to v11, only includes versioning tweaks)